### PR TITLE
fix: update encoding utils & `CheckArguments` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,37 +142,15 @@ Check if domain is starknet.id domain
 
 _utils.**decodeDomain**(encoded: bigint[]) => string_
 
-Decode starknetid domain '454245...' -> 'test.stark'
-
-**decode()**
-
-_utils.**decode**(felt: bigint) => string_
-
-Encode bigint into string
+Decode starknetid domain represented as an array of bigint `[454245]` ->
+`test.stark`
 
 **encodeDomain()**
 
-_utils.**encodeDomain**(domain: string) => bigint[]_
+_utils.**encodeDomain**(domain: string | undefined | null) => bigint[]_
 
-Encode starknetid domains and subdomains 'test.stark'.. -> '454245..'
-
-**encode()**
-
-_utils.**encode**(decoded: string | undefined) => bigint_
-
-Encode string into bigint. If string is undefined it will return BigInt(0).
-
-**encodeSeveral()**
-
-_utils.**encodeSeveral**(domains: string[]) => string[]_
-
-Encode several domain. Useful for subdomains.
-
-**decodeSeveral()**
-
-_utils.**decodeSeveral**(domains: bigint[][]) => string[]_
-
-Decode several domains.
+Encode starknetid domains and subdomains to an array bigint `test.stark` ->
+`[454245]`
 
 **getNamingContract()**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknetid.js",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "JavaScript library for Starknet ID",
   "private": false,
   "license": "MIT",

--- a/packages/core/__test__/utils.test.ts
+++ b/packages/core/__test__/utils.test.ts
@@ -13,37 +13,47 @@ const basicAlphabet = "abcdefghijklmnopqrstuvwxyz0123456789-";
 const bigAlphabet = "这来";
 const totalAlphabet = basicAlphabet + bigAlphabet;
 
-describe("Should test encoding/decoding hooks 2500 times", () => {
-  it("Should test encode and decode functions with a random string", () => {
+describe("Should test encodeDomain and decodeDomain 2500 times", () => {
+  it("Should test encodeDomain and decodeDomain functions with a random string", () => {
     for (let index = 0; index < 2500; index++) {
       const randomString = generateString(10, totalAlphabet);
-      expect(utils.decode(utils.encode(randomString))).toBe(randomString);
-    }
-  });
-
-  it("Should test decode and encode functions with a number", () => {
-    for (let index = 0; index < 2500; index++) {
-      const decoded = utils.decode(BigInt(index));
-      expect(utils.encode(decoded).toString()).toBe(index.toString());
-    }
-  });
-
-  it("Should test encode and decodeDomain functions with a random string", () => {
-    for (let index = 0; index < 2500; index++) {
-      const randomString = generateString(10, totalAlphabet);
-      expect(utils.decodeDomain([utils.encode(randomString)])).toBe(
+      expect(utils.decodeDomain(utils.encodeDomain(randomString))).toBe(
         randomString + ".stark",
       );
     }
   });
 
-  it("Should test encodeSeveral with subdomain", () => {
+  it("Should test decodeDomain functions with a number", () => {
+    for (let index = 0; index < 2500; index++) {
+      const decoded = utils.decodeDomain([BigInt(index)]);
+      expect(utils.encodeDomain(decoded).toString()).toBe(index.toString());
+    }
+  });
+
+  it("Should test encodeDomain and decodeDomain functions with a random string not ending with .stark", () => {
+    for (let index = 0; index < 2500; index++) {
+      const randomString = generateString(10, totalAlphabet);
+      expect(utils.decodeDomain(utils.encodeDomain(randomString))).toBe(
+        randomString + ".stark",
+      );
+    }
+  });
+
+  it("Should test encodeDomain and decodeDomain functions with a random string ending .stark", () => {
+    for (let index = 0; index < 2500; index++) {
+      const randomString = generateString(10, totalAlphabet);
+      expect(
+        utils.decodeDomain(utils.encodeDomain(randomString + ".stark")),
+      ).toBe(randomString + ".stark");
+    }
+  });
+
+  it("Should test encodeDomain with subdomain not ending with.stark", () => {
     for (let index = 0; index < 2500; index++) {
       const randomString = generateString(10, totalAlphabet);
       const randomString1 = generateString(10, totalAlphabet);
-      const encoded = utils
-        .encodeSeveral([randomString, randomString1])
-        .map((element) => BigInt(element));
+
+      const encoded = utils.encodeDomain(randomString + "." + randomString1);
 
       expect(utils.decodeDomain(encoded)).toBe(
         randomString + "." + randomString1 + ".stark",
@@ -51,21 +61,46 @@ describe("Should test encoding/decoding hooks 2500 times", () => {
     }
   });
 
-  it("Should test useDecoded and useEncoded hook with a number", () => {
+  it("Should test encodeDomain with subdomain ending with.stark", () => {
     for (let index = 0; index < 2500; index++) {
-      const decoded = utils.decodeDomain([BigInt(index)]);
-      expect(
-        utils.encode(decoded.substring(0, decoded.length - 6)).toString(),
-      ).toBe(index.toString());
+      const randomString = generateString(10, totalAlphabet);
+      const randomString1 = generateString(10, totalAlphabet);
+
+      const encoded = utils.encodeDomain(
+        randomString + "." + randomString1 + ".stark",
+      );
+
+      expect(utils.decodeDomain(encoded)).toBe(
+        randomString + "." + randomString1 + ".stark",
+      );
     }
   });
 
-  it("Should test useDecoded and useEncoded with a subdomain", () => {
+  it("Should test decodeDomain and encodeDomain functions with a number", () => {
+    for (let index = 0; index < 2500; index++) {
+      const decoded = utils.decodeDomain([BigInt(index)]);
+      expect(
+        utils.encodeDomain(decoded.substring(0, decoded.length - 6)).toString(),
+      ).toBe(index.toString());
+    }
+  });
+});
+
+describe("Should test encodeDomain and decodeDomain on special cases", () => {
+  it("Should test decodeDomain and encodeDomain with a subdomain", () => {
     const decoded = utils.decodeDomain([BigInt(1499554868251), BigInt(18925)]);
     expect(decoded).toBe("fricoben.ben.stark");
   });
 
-  it("Should test encode with an undefined domain", () => {
-    expect(utils.decode(utils.encode(undefined))).toBe("");
+  it("Should test encodeDomain with an undefined domain", () => {
+    expect(utils.decodeDomain(utils.encodeDomain(undefined))).toBe("");
+  });
+
+  it("Should test encodeDomain with a null domain", () => {
+    expect(utils.decodeDomain(utils.encodeDomain(null))).toBe("");
+  });
+
+  it("Should test encodeDomain with an empty domain", () => {
+    expect(utils.decodeDomain(utils.encodeDomain(""))).toBe("");
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknetid.js",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "keywords": [
     "starknet",
     "starknetid",

--- a/packages/core/src/starknetIDNavigator/default.ts
+++ b/packages/core/src/starknetIDNavigator/default.ts
@@ -315,11 +315,16 @@ export class StarknetIdNavigator implements StarknetIdNavigatorInterface {
     idDomainOrAddr: string | number,
   ): Promise<number> {
     if (typeof idDomainOrAddr === "string") {
-      if (isStarkDomain(idDomainOrAddr)) {
+      if (/^[-+]?[0-9]+$/.test(idDomainOrAddr)) {
+        // is a number
+        return parseInt(idDomainOrAddr);
+      } else if (isStarkDomain(idDomainOrAddr)) {
+        // is a starkDomain
         return this.getStarknetId(idDomainOrAddr).then((id: number) => {
           return id;
         });
-      } else {
+      } else if (/^[-+]?0x[0-9a-f]+$/i.test(idDomainOrAddr)) {
+        // is a hex address
         const checkSumAddr = getChecksumAddress(idDomainOrAddr);
         if (validateChecksumAddress(checkSumAddr)) {
           return this.getStarkName(idDomainOrAddr).then((name: string) => {
@@ -328,8 +333,10 @@ export class StarknetIdNavigator implements StarknetIdNavigatorInterface {
             });
           });
         } else {
-          throw new Error("Invalid idDomainOrAddr argument");
+          throw new Error("Invalid Starknet address");
         }
+      } else {
+        throw new Error("Invalid idDomainOrAddr argument");
       }
     } else if (typeof idDomainOrAddr === "number") {
       return idDomainOrAddr;


### PR DESCRIPTION
- pass `encode` and `decode` functions to private 
- update `encodeDomain` function to accept null or undefined as argument
- update utils tests
- update documentation
- update CheckArguments function so `tokenId` can either be a string or a number