### PR TITLE
feat: add identicons option in getProfileData function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknetid.js",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "JavaScript library for Starknet ID",
   "private": false,
   "license": "MIT",

--- a/packages/core/__test__/profile.test.ts
+++ b/packages/core/__test__/profile.test.ts
@@ -132,28 +132,6 @@ describe("test starknetid.js sdk", () => {
           0,
         ],
       },
-      {
-        contractAddress: IdentityContract,
-        entrypoint: "set_verifier_data",
-        calldata: [
-          "1", // token_id
-          shortString.encodeShortString("nft_pp_contract"), // field
-          NFTContract, // value
-          0,
-        ],
-      },
-      {
-        contractAddress: IdentityContract,
-        entrypoint: "set_extended_verifier_data",
-        calldata: [
-          "1", // token_id
-          shortString.encodeShortString("nft_pp_id"), // field
-          "2", // length
-          1, // value
-          0,
-          0,
-        ],
-      },
     ]);
     await provider.waitForTransaction(transaction_hash2);
   });
@@ -172,6 +150,93 @@ describe("test starknetid.js sdk", () => {
       });
     });
 
+    test("getProfileData should return an undefined profile picture url", async () => {
+      const starknetIdNavigator = new StarknetIdNavigator(
+        provider,
+        constants.StarknetChainId.SN_GOERLI,
+        {
+          naming: NamingContract,
+          identity: IdentityContract,
+        },
+      );
+      expect(starknetIdNavigator).toBeInstanceOf(StarknetIdNavigator);
+      const profile = await starknetIdNavigator.getProfileData(
+        account.address,
+        false,
+        otherAccount.address,
+        otherAccount.address,
+        otherAccount.address,
+      );
+      const expectedProfile = {
+        name: "ben.stark",
+        twitter: undefined,
+        github: undefined,
+        discord: "123",
+        proofOfPersonhood: false,
+        profilePicture: undefined,
+      };
+      expect(profile).toStrictEqual(expectedProfile);
+    });
+
+    test("getProfileData should return an identicon url", async () => {
+      const starknetIdNavigator = new StarknetIdNavigator(
+        provider,
+        constants.StarknetChainId.SN_GOERLI,
+        {
+          naming: NamingContract,
+          identity: IdentityContract,
+        },
+      );
+      expect(starknetIdNavigator).toBeInstanceOf(StarknetIdNavigator);
+      const profile = await starknetIdNavigator.getProfileData(
+        account.address,
+        true,
+        otherAccount.address,
+        otherAccount.address,
+        otherAccount.address,
+      );
+      const expectedProfile = {
+        name: "ben.stark",
+        twitter: undefined,
+        github: undefined,
+        discord: "123",
+        proofOfPersonhood: false,
+        profilePicture: "https://starknet.id/api/identicons/1",
+      };
+      expect(profile).toStrictEqual(expectedProfile);
+    });
+  });
+
+  describe("getProfileData with nft profile picture", () => {
+    beforeAll(async () => {
+      // Add nft pp verifier data
+      const { transaction_hash } = await otherAccount.execute([
+        {
+          contractAddress: IdentityContract,
+          entrypoint: "set_verifier_data",
+          calldata: [
+            "1", // token_id
+            shortString.encodeShortString("nft_pp_contract"), // field
+            NFTContract, // value
+            0,
+          ],
+        },
+        {
+          contractAddress: IdentityContract,
+          entrypoint: "set_extended_verifier_data",
+          calldata: [
+            "1", // token_id
+            shortString.encodeShortString("nft_pp_id"), // field
+            "2", // length
+            1, // value
+            0,
+            0,
+          ],
+        },
+      ]);
+      await provider.waitForTransaction(transaction_hash);
+    });
+
     test("getProfileData should return the right values", async () => {
       const starknetIdNavigator = new StarknetIdNavigator(
         provider,
@@ -184,6 +249,7 @@ describe("test starknetid.js sdk", () => {
       expect(starknetIdNavigator).toBeInstanceOf(StarknetIdNavigator);
       const profile = await starknetIdNavigator.getProfileData(
         account.address,
+        true,
         otherAccount.address,
         otherAccount.address,
         otherAccount.address,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknetid.js",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "keywords": [
     "starknet",
     "starknetid",

--- a/packages/core/src/starknetIdNavigator/default.ts
+++ b/packages/core/src/starknetIdNavigator/default.ts
@@ -369,6 +369,7 @@ export class StarknetIdNavigator implements StarknetIdNavigatorInterface {
 
   public async getProfileData(
     address: string,
+    identicons?: boolean,
     verifier?: string,
     pfp_verifier?: string,
     pop_verifier?: string,
@@ -529,6 +530,8 @@ export class StarknetIdNavigator implements StarknetIdNavigatorInterface {
         // extract nft_image from profile data
         const profilePicture = profilePictureMetadata
           ? await this.fetchImageUrl(profilePictureMetadata)
+          : identicons
+          ? `https://starknet.id/api/identicons/${data[1][0].toString()}`
           : undefined;
 
         return {

--- a/packages/core/src/starknetIdNavigator/default.ts
+++ b/packages/core/src/starknetIdNavigator/default.ts
@@ -369,7 +369,7 @@ export class StarknetIdNavigator implements StarknetIdNavigatorInterface {
 
   public async getProfileData(
     address: string,
-    identicons?: boolean,
+    useDefaultPfp: boolean = true,
     verifier?: string,
     pfp_verifier?: string,
     pop_verifier?: string,
@@ -530,7 +530,7 @@ export class StarknetIdNavigator implements StarknetIdNavigatorInterface {
         // extract nft_image from profile data
         const profilePicture = profilePictureMetadata
           ? await this.fetchImageUrl(profilePictureMetadata)
-          : identicons
+          : useDefaultPfp
           ? `https://starknet.id/api/identicons/${data[1][0].toString()}`
           : undefined;
 

--- a/packages/core/src/starknetIdNavigator/interface.ts
+++ b/packages/core/src/starknetIdNavigator/interface.ts
@@ -141,9 +141,10 @@ export abstract class StarknetIdNavigatorInterface {
    * Get user stark profile data from his address
    * Use this function to retrive starkname, profile picture url, social networks ids and proof of personhood verification status.
    * If no verifier is provided, it will use the starknet.id verifiers contract addresses
-   * If no NFT is set as profile picture, it will return zeros.
+   * If no NFT is set as profile picture and identicons is set to true it will return the identicons url for this starknetid.
    *
    * @param address (string)
+   * @param identicons boolean to return identicons url if no profile picture is set (optional)
    * @param verifier contract address for social networks (optional)
    * @param pfp_verifier contract address for profile picture (optional)
    * @param pop_verifier contract address for proof of personhood (optional)
@@ -151,6 +152,7 @@ export abstract class StarknetIdNavigatorInterface {
    */
   public abstract getProfileData(
     address: string,
+    identicons?: boolean,
     verifier?: string,
     pfp_verifier?: string,
     pop_verifier?: string,

--- a/packages/core/src/starknetIdNavigator/interface.ts
+++ b/packages/core/src/starknetIdNavigator/interface.ts
@@ -141,10 +141,10 @@ export abstract class StarknetIdNavigatorInterface {
    * Get user stark profile data from his address
    * Use this function to retrive starkname, profile picture url, social networks ids and proof of personhood verification status.
    * If no verifier is provided, it will use the starknet.id verifiers contract addresses
-   * If no NFT is set as profile picture and identicons is set to true it will return the identicons url for this starknetid.
+   * If no NFT is set as profile picture it will return the starknetid pfp url for this address. To disable this behavior, set the useDefaultPfp parameter to false.
    *
    * @param address (string)
-   * @param identicons boolean to return identicons url if no profile picture is set (optional)
+   * @param useDefaultPfp boolean to return the default starknetid url if no profile picture is set (optional)
    * @param verifier contract address for social networks (optional)
    * @param pfp_verifier contract address for profile picture (optional)
    * @param pop_verifier contract address for proof of personhood (optional)
@@ -152,7 +152,7 @@ export abstract class StarknetIdNavigatorInterface {
    */
   public abstract getProfileData(
     address: string,
-    identicons?: boolean,
+    useDefaultPfp?: boolean,
     verifier?: string,
     pfp_verifier?: string,
     pop_verifier?: string,


### PR DESCRIPTION
This PR adds an optional argument `useDefaultPfp` in `getProfileData` function. If sets to `true` it will return the url of the identicons of that starknetid if the user has not set any nft as profile picture, if sets to `false` it will return `undefined`. If not specified by the user it will be set to `true`. 